### PR TITLE
Recommending `git add --patch`

### DIFF
--- a/common-flow.md
+++ b/common-flow.md
@@ -176,7 +176,7 @@ interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
        documentation:
        <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines>
     2. You SHOULD never blindly commit all changes with "git commit -a". It is
-       RECOMMENDED you use "git add -i" to add individual changes to the staging
+       RECOMMENDED you use "git add -p" or "git add -i" to add individual changes to the staging
        area so you are fully aware of what you are committing.
     3. You SHOULD always use "--force-with-lease" when doing a force push. The
        regular "--force" option is dangerous and destructive. More


### PR DESCRIPTION
In the "best practices" section, there's a recommendation to use `git add --interactive`. 
I've added to this to highlight the shortcut to an interactive add of all files which cuts a few steps (selecting 'patch', and the required files) from common uses of interactive add.
